### PR TITLE
add alt to img tag for a11y accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class MyWrapper extends Component {
         <ResponsiveMasonry columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}>
         	<Masonry>
         		{images.map((image, i) =>
-        			<img key={i} src={image} style={{width: "100%", display: "block"}} />
+        			<img key={i} src={image} style={{width: "100%", display: "block"}} alt="" />
         		)}
         	</Masonry>
     	</ResponsiveMasonry>


### PR DESCRIPTION
eslint will complain about this if you have the jsx-a11y installed.